### PR TITLE
SPOTIFY_NAME changed on server

### DIFF
--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SPOTIFY_URL=http://repository.spotify.com/pool/non-free/s/spotify-client/
-SPOTIFY_NAME=spotify-client_1.0.57.474.gca9c9538-30_amd64.deb
+SPOTIFY_NAME=spotify-client_1.0.59.395.ge6ca9946-18_amd64.deb
 
 if [ `id -u` = 0 ] ; then
         echo "Please don't run this script as root."


### PR DESCRIPTION
Gave 404 file not found as new version of spotify.

Long term what is the to stop this happening over and over again? 