### PR TITLE
Fixes icons not showing bug

### DIFF
--- a/install-spotify.sh
+++ b/install-spotify.sh
@@ -53,7 +53,7 @@ if [[ " $file_content " =~ "export PATH="$HOME/bin:$PATH"" ]]
 fi
 
 cd ../
-gtk-update-icon-cache
+cp -s /usr/share/icons/hicolor/index.theme $HOME/.local/share/icons/hicolor 
 update-desktop-database -q
 cp spotify.desktop $HOME/.local/share/applications/
 echo "Cleaning folder..."

--- a/uninstall-spotify.sh
+++ b/uninstall-spotify.sh
@@ -3,3 +3,4 @@ rm $HOME/.local/share/applications/spotify.desktop
 rm $HOME/.local/share/icons/hicolor/128x128/apps/spotify-client.png
 rm $HOME/bin/spotify
 rm -rf $HOME/.local/share/spotify
+rm $HOME/.local/share/icons/hicolor/index.theme


### PR DESCRIPTION
So after some tinkering it turned out that all I had to do was to copy the system index.theme file to the .local folder and then the icon showed up directly after running the installation script. 

No idea why but it works... Tested multiple times with and without the file copied. No need for gtk-update-icon-cache. 

Solves Issue #1 